### PR TITLE
exclude backup files from ankiweb

### DIFF
--- a/zipping
+++ b/zipping
@@ -1,1 +1,1 @@
-zip readableAddons.zip *py README.md LICENSE config* zipping ankiweb
+zip readableAddons.zip *py README.md LICENSE config* zipping ankiweb --exclude \*~


### PR DESCRIPTION
first of all: Thanks for another useful add-on. Other people have already asked about readable folder names, see [here](https://anki.tenderapp.com/discussions/ankidesktop/29337-anki-21-add-ons-folder).

Your "zipping" command doesn't exclude backup files (files ending with "~") from the zip file you upload to Ankiweb.

This change is very minor and just aesthetic. I can see that you might find this irrelevant.

The command line parameter I added was only tested on Linux (Fedora).

My motivation: I download your new add-on from Ankiweb and to learn more about them I look at them on my file system. I really don't like backup files in the same folder .... And maybe one day you'll accidently upload something interesting ...

At the moment I have backup files in these of your add-ons from ankiweb.

    * Edit cards template with python and a domain specific language

    * Enhance main window

    * Compile latex during addedition and warn in case of error

    * Export cards selected in the Browser

    * Opening the same window multiple time

    * Postpone cards review

    * Obtain a beautiful readable and debuggable database for anki

    * Add-on folder with readable names