### PR TITLE
[Feature] Windows support, remove symlinks of uninstalled add-ons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,17 @@
 # Having readable add-on folder
 ## Rationale
-The add-ons folder contains one folder by add-on. Each folder's name
+The add-ons folder contains one folder per add-on. Each folder's name
 is a string of digits. This is quite horrible for a human who wants to
 go read or edit the code of an add-on.
 
-Thus, this add-on create another folder, containing symlinks with the
-name of the add-on to the add-on folder.
+Thus, this add-on creates another folder containing symlinks (directory 
+junctions on Windows) with the name of an add-on pointing to that add-on
+folder.
 
 ## Usage
 Install this add-on and start Anki. That's all. The symlinks are
-created while Anki start. If you install a new add-on, its symlink
+created while Anki starts. If you install a new add-on, its symlink
 won't be created until you restart Anki.
-
-Note also that symlinks are not deleted. Thus a symlink may break if
-you delete an add-on. (TODO: change that ?)
 
 ## Configuration
 By default, the new folder is in the same folder as the original

--- a/README.md
+++ b/README.md
@@ -1,26 +1,22 @@
 # Having readable add-on folder
 ## Rationale
 The add-ons folder contains one folder by add-on. Each folder's name
-is a string of digit. This is quite horrible for a human who want to
+is a string of digits. This is quite horrible for a human who wants to
 go read or edit the code of an add-on.
 
 Thus, this add-on create another folder, containing symlinks with the
 name of the add-on to the add-on folder.
 
-## Warning
-This does not work on windows. Because this add-ons create symbolic
-links, and windows can't create them without admin privilege.
-
 ## Usage
-Install this add-on and start anki. That's all. The symlinks are
-created while anki start. If you install a new add-on, it's symlink
-won't be created untill you restart anki.
+Install this add-on and start Anki. That's all. The symlinks are
+created while Anki start. If you install a new add-on, its symlink
+won't be created until you restart Anki.
 
 Note also that symlinks are not deleted. Thus a symlink may break if
 you delete an add-on. (TODO: change that ?)
 
 ## Configuration
-By default the new folder is in the same folder than the original
+By default, the new folder is in the same folder as the original
 addons directory. You can change this directory in newFolder.
 
 The name of the new folder, by default, is "namedAddons", it can also

--- a/__init__.py
+++ b/__init__.py
@@ -1,8 +1,4 @@
 import sys
 
-from anki.utils import isWin
-
-if not isWin:
-    from . import readableAddons
-else:
-    print((f"""I beg your pardon. Currently the add-on "Add-on folder with readable names" does not work on windows. This is because this add-on is used to create symbolic links, and they can't be created without admin privilege on windows. You may want to uninstall add-on 519936472.""", sys.stderr))
+from . import readableAddons
+    

--- a/readableAddons.py
+++ b/readableAddons.py
@@ -17,6 +17,7 @@ if not os.path.exists(newFolder):
         print(
             (f"""There is an error with the configuration of the addon "Add-on folder with readable names". Currently, it asks to use directory {originalFolder}, and you don't have the permissions to create a folder there. So, either you should change the permission of this folder, or you should select another folder.""", sys.stderr))
 
+installedAddonNames = set()
 for fileName in os.listdir(originalFolder):
     originalAddonDir = os.path.join(originalFolder, fileName)
     if os.path.isdir(originalAddonDir):
@@ -29,9 +30,15 @@ for fileName in os.listdir(originalFolder):
                 name = j["name"]
         else:
             name = fileName
+        installedAddonNames.add(name)
         newAddonDir = os.path.join(newFolder, name)
         if not os.path.exists(newAddonDir):
             if isWin:
                 os.system(r'mklink /J "{}" "{}"'.format(newAddonDir, originalAddonDir))
             else:
                 os.symlink(originalAddonDir, newAddonDir)
+
+invalidSymlinks = set(os.listdir(newFolder)) - installedAddonNames
+for invalidSymlinkName in invalidSymlinks:
+    invalidSymlinkPath = os.path.join(newFolder, invalidSymlinkName)
+    os.remove(invalidSymlinkPath)

--- a/readableAddons.py
+++ b/readableAddons.py
@@ -4,6 +4,7 @@ import os.path
 import sys
 
 from aqt import mw
+from anki.utils import isWin
 
 from .config import getNewFolder
 
@@ -30,4 +31,7 @@ for fileName in os.listdir(originalFolder):
             name = fileName
         newAddonDir = os.path.join(newFolder, name)
         if not os.path.exists(newAddonDir):
-            os.symlink(originalAddonDir, newAddonDir)
+            if isWin:
+                os.system(r'mklink /J "{}" "{}"'.format(newAddonDir, originalAddonDir))
+            else:
+                os.symlink(originalAddonDir, newAddonDir)


### PR DESCRIPTION
Hello,
(sorry for the last PR, this is revised one)

I found your add-on with exactly the functionality I need, it can be simply updated to support Windows properly without requiring admin privileges.

We can essentially use NTFS junctions for directories instead of symlinks on Windows. Junctions have the advantage that they do not require admin privileges (see [https://superuser.com/questions/343074/directory-junction-vs-directory-symbolic-link](https://superuser.com/questions/343074/directory-junction-vs-directory-symbolic-link)).

Also, I added code that removes invalid symlinks of uninstalled add-ons.

