### PR TITLE
handle slash (path separator) in add-on name

### DIFF
--- a/readableAddons.py
+++ b/readableAddons.py
@@ -13,8 +13,15 @@ if not os.path.exists(newFolder):
     try:
         os.makedirs(newFolder)
     except PermissionError:
-        print(
-            (f"""There is an error with the configuration of the addon "Add-on folder with readable names". Currently, it asks to use directory {originalFolder}, and you don't have the permissions to create a folder there. So, either you should change the permission of this folder, or you should select another folder.""", sys.stderr))
+        msg = (
+            "There is an error with the configuration of the addon"
+            '"Add-on folder with readable names". Currently, it asks '
+            f"to use directory {originalFolder}, and you don't have the "
+            "permissions to create a folder there. So, either you should "
+            "change the permission of this folder, or you should select "
+            "another folder."
+        )
+        print(msg, sys.stderr)
 
 for entry in os.listdir(originalFolder):
     originalAddonDir = os.path.join(originalFolder, entry)

--- a/readableAddons.py
+++ b/readableAddons.py
@@ -16,8 +16,8 @@ if not os.path.exists(newFolder):
         print(
             (f"""There is an error with the configuration of the addon "Add-on folder with readable names". Currently, it asks to use directory {originalFolder}, and you don't have the permissions to create a folder there. So, either you should change the permission of this folder, or you should select another folder.""", sys.stderr))
 
-for fileName in os.listdir(originalFolder):
-    originalAddonDir = os.path.join(originalFolder, fileName)
+for entry in os.listdir(originalFolder):
+    originalAddonDir = os.path.join(originalFolder, entry)
     if os.path.isdir(originalAddonDir):
         metaFile = os.path.join(originalAddonDir, "meta.json")
         if os.path.exists(metaFile):
@@ -28,7 +28,7 @@ for fileName in os.listdir(originalFolder):
                 name = j["name"]
                 name = name.replace("/", "_")
         else:
-            name = fileName
+            name = entry
         newAddonDir = os.path.join(newFolder, name)
         if not os.path.exists(newAddonDir):
             os.symlink(originalAddonDir, newAddonDir)

--- a/readableAddons.py
+++ b/readableAddons.py
@@ -26,6 +26,7 @@ for fileName in os.listdir(originalFolder):
                 if "name" not in j:
                     continue
                 name = j["name"]
+                name = name.replace("/", "_")
         else:
             name = fileName
         newAddonDir = os.path.join(newFolder, name)

--- a/readableAddons.py
+++ b/readableAddons.py
@@ -7,28 +7,29 @@ from aqt import mw
 
 from .config import getNewFolder
 
-originalFolder = mw.pm.addonFolder()
-newFolder = getNewFolder()
-if not os.path.exists(newFolder):
+original_folder = mw.pm.addonFolder()
+new_folder = getNewFolder()
+
+if not os.path.exists(new_folder):
     try:
-        os.makedirs(newFolder)
+        os.makedirs(new_folder)
     except PermissionError:
         msg = (
             "There is an error with the configuration of the addon"
             '"Add-on folder with readable names". Currently, it asks '
-            f"to use directory {originalFolder}, and you don't have the "
+            f"to use directory {original_folder}, and you don't have the "
             "permissions to create a folder there. So, either you should "
             "change the permission of this folder, or you should select "
             "another folder."
         )
         print(msg, sys.stderr)
 
-for entry in os.listdir(originalFolder):
-    originalAddonDir = os.path.join(originalFolder, entry)
-    if os.path.isdir(originalAddonDir):
-        metaFile = os.path.join(originalAddonDir, "meta.json")
-        if os.path.exists(metaFile):
-            with open(metaFile, "r") as f:
+for entry in os.listdir(original_folder):
+    original_addon_dir = os.path.join(original_folder, entry)
+    if os.path.isdir(original_addon_dir):
+        meta_file = os.path.join(original_addon_dir, "meta.json")
+        if os.path.exists(meta_file):
+            with open(meta_file, "r") as f:
                 j = json.load(f)
                 if "name" not in j:
                     continue
@@ -36,6 +37,6 @@ for entry in os.listdir(originalFolder):
                 name = name.replace("/", "_")
         else:
             name = entry
-        newAddonDir = os.path.join(newFolder, name)
-        if not os.path.exists(newAddonDir):
-            os.symlink(originalAddonDir, newAddonDir)
+        new_addon_dir = os.path.join(new_folder, name)
+        if not os.path.exists(new_addon_dir):
+            os.symlink(original_addon_dir, new_addon_dir)


### PR DESCRIPTION
without my commit about the slash your add-on throws errors with multiple of my add-ons (because I often use the forward slash in add-on names).

the other three commits are just about optics.